### PR TITLE
Same convention for mkdtemp as for mktemp.

### DIFF
--- a/posix/unix.lisp
+++ b/posix/unix.lisp
@@ -51,8 +51,11 @@
     (with-foreign-string (ptr (filename template))
       (values (%mkstemp ptr) (foreign-string-to-lisp ptr)))))
 
-(defsyscall "mkdtemp" :string
+(defsyscall ("mkdtemp" %mkdtemp) :string
   (template filename-designator))
+
+(defun mkdtemp (&optional (template ""))
+  (%mkdtemp (concatenate 'string template "XXXXXX")))
 
 ;;;; unistd.h
 


### PR DESCRIPTION
This is unfortunately not backwards-compatible, but I was wondering why `MKDTEMP` doesn't follow the same convention as the other `MK*TEMP` functions, so I propose the following change so that a simple call like `(MKDTEMP)` immediately produces a valid temporary directory.