### PR TITLE
kludges to get Osicat to load on Windows

### DIFF
--- a/osicat.asd
+++ b/osicat.asd
@@ -37,7 +37,8 @@
   :author "Nikodemus Siivola <nikodemus@random-state.net>"
   :description "A lightweight operating system interface"
   :license "MIT"
-  :depends-on (cffi cffi-grovel alexandria trivial-features)
+  :depends-on (cffi alexandria trivial-features)
+  :defsystem-depends-on (cffi-grovel)
   :components
   ((:module osicat-sys
     :pathname #p"src/"

--- a/src/osicat.lisp
+++ b/src/osicat.lisp
@@ -103,7 +103,9 @@ of SETF ENVIRONMENT."
             (#.nix:s-ifchr  :character-device)
             (#.nix:s-ifblk  :block-device)
             (#.nix:s-ifreg  :regular-file)
+            #-windows ; KLUDGE
             (#.nix:s-iflnk  :symbolic-link)
+            #-windows ; KLUDGE
             (#.nix:s-ifsock :socket)
             (#.nix:s-ififo  :pipe)
             (otherwise
@@ -523,18 +525,19 @@ not exist, or link exists already."
 ;;;; File permissions
 
 (define-constant +permissions+
-    '((:user-read    . #.nix:s-irusr)
-      (:user-write   . #.nix:s-iwusr)
-      (:user-exec    . #.nix:s-ixusr)
-      (:group-read   . #.nix:s-irgrp)
-      (:group-write  . #.nix:s-iwgrp)
-      (:group-exec   . #.nix:s-ixgrp)
-      (:other-read   . #.nix:s-iroth)
-      (:other-write  . #.nix:s-iwoth)
-      (:other-exec   . #.nix:s-ixoth)
-      (:set-user-id  . #.nix:s-isuid)
-      (:set-group-id . #.nix:s-isgid)
-      (:sticky       . #.nix:s-isvtx))
+    (append '((:user-read    . #.nix:s-irusr)
+              (:user-write   . #.nix:s-iwusr)
+              (:user-exec    . #.nix:s-ixusr))
+            #-windows ; KLUDGE
+            '((:group-read   . #.nix:s-irgrp)
+              (:group-write  . #.nix:s-iwgrp)
+              (:group-exec   . #.nix:s-ixgrp)
+              (:other-read   . #.nix:s-iroth)
+              (:other-write  . #.nix:s-iwoth)
+              (:other-exec   . #.nix:s-ixoth)
+              (:set-user-id  . #.nix:s-isuid)
+              (:set-group-id . #.nix:s-isgid)
+              (:sticky       . #.nix:s-isvtx)))
   :test #'equal)
 
 (defun file-permissions (pathspec)


### PR DESCRIPTION
I'd quite forgotten Osicat had moved here, and push on

     https://gitlab.common-lisp.net/osicat/osicat

. Oops. Here's the corresponding pull request.
