### PR TITLE
Add support for posix_fallocate

### DIFF
--- a/doc/posix-internals.txt
+++ b/doc/posix-internals.txt
@@ -224,6 +224,10 @@ stored in this condition and can be accessed with SYSCALL-ERRNO.
 [TBA: some interface to strerror, to get the user-readable translation
 of the error number]
 
+Note, there are calls where "errno" is NOT set and an error code is
+communicated through the return value instead. e.g. posix_fallocate().
+These errors are also signalled as an error.
+
 We do not automatically translate the returned value into "Lispy"
 objects - for example, OSICAT-POSIX:OPEN returns a small integer, not a
 stream.  Exception: boolean-returning functions (or, more commonly,

--- a/posix/early.lisp
+++ b/posix/early.lisp
@@ -39,7 +39,8 @@
   ((object :initform nil :initarg :object :reader posix-error-object)
    (syscall :initform nil :initarg :syscall :reader posix-error-syscall))
   (:documentation
-   "POSIX-ERRORs are signalled whenever ERRNO is set by a POSIX call."))
+   "POSIX-ERRORs are signalled whenever ERRNO is set by a POSIX call or
+where the POSIX call signals an error via the return value."))
 
 ;;; HASH TABLE mapping keywords (such as :EAGAIN) to symbols denoting
 ;;; subtypes of POSIX-ERROR.
@@ -96,6 +97,9 @@
 (defun syscall-signal-posix-error (return-value object syscall)
   (declare (ignore return-value))
   (posix-error (get-errno) object syscall))
+
+(defun syscall-signal-posix-error-via-return-value (return-value object syscall)
+  (posix-error return-value object syscall))
 
 ;;; Error predicate that always returns NIL.  Not actually used
 ;;; because the ERRNO-WRAPPER optimizes this call away.

--- a/posix/packages.lisp
+++ b/posix/packages.lisp
@@ -72,6 +72,7 @@
    #:fchdir
    #:fchmod
    #:fcntl
+   #:posix-fallocate
    #:fork
    #:fstat
    #:fstatvfs

--- a/posix/windows.lisp
+++ b/posix/windows.lisp
@@ -28,7 +28,7 @@
 
 (define-unsupported-functions
   clock-getres clock-gettime clock-settime closedir closelog dirfd fchdir
-  fchmod fcntl fork fstatvfs fsync getdomainname getegid geteuid getgid
+  fchmod fcntl posix-fallocate fork fstatvfs fsync getdomainname getegid geteuid getgid
   getgrgid getgrnam getpagesize getpgid getpgrp getpid getppid getpriority
   getpwnam getpwuid getrlimit getrusage gettimeofday getuid ioctl link lockf
   lstat mkdtemp mkfifo mknod mkstemp mlock mlockall mmap mprotect msync munlock

--- a/posix/wrappers.lisp
+++ b/posix/wrappers.lisp
@@ -148,6 +148,14 @@
     ((fd ("int" file-descriptor-designator)) (cmd :int) (arg :pointer))
   "return fcntl(fd, cmd, arg);")
 
+#-windows
+(defwrapper "posix_fallocate" ("int" (errno-wrapper :int
+                                                    :error-predicate (lambda (r) (not (zerop r)))
+                                                    :error-generator syscall-signal-posix-error-via-return-value))
+  (fd ("int" file-descriptor-designator))
+  (offset ("off_t" off))
+  (length ("off_t" off)))
+
 ;;;; Miscellaneous
 
 (defwrapper* "get_errno" :int ()

--- a/tests/posix.lisp
+++ b/tests/posix.lisp
@@ -673,9 +673,9 @@
     (let ((filename (make-pathname :name "fallocate.error" :type "1"
                                    :defaults *test-directory*)))
       (handler-case
-          (let* ((fd (nix:open filename nix:o-creat nix:o-rdwr)))
+          (let* ((fd (nix:open filename (logior nix:o-creat nix:o-rdwr))))
             (unwind-protect
-                 (nix:posix-fallocate fd 0 -100)
+                 (nix:posix-fallocate fd 0 0)
               (ignore-errors
                 (nix:close fd)
                 (nix:unlink filename))))


### PR DESCRIPTION
Hi, I needed to add support for my favourite posix function: posix_fallocate. It is a bit different to other posix calls in that it does NOT set errno. Instead, it communicates an error via return value. I think there is one other call like this: posix_fadvise (not implemented in this PR).