### PR TITLE
posix_fallocate is supported on Linux

### DIFF
--- a/posix/wrappers.lisp
+++ b/posix/wrappers.lisp
@@ -148,7 +148,7 @@
     ((fd ("int" file-descriptor-designator)) (cmd :int) (arg :pointer))
   "return fcntl(fd, cmd, arg);")
 
-#-windows
+#+linux
 (defwrapper "posix_fallocate" ("int" (errno-wrapper :int
                                                     :error-predicate (lambda (r) (not (zerop r)))
                                                     :error-generator syscall-signal-posix-error-via-return-value))


### PR DESCRIPTION
I saw that this posix-standard function is a problem for OS X users. It should be #+linux for now.