### PR TITLE
Added the poll() system call and fixed ioctl only accepting a pointer argument

### DIFF
--- a/posix/packages.lisp
+++ b/posix/packages.lisp
@@ -390,9 +390,18 @@
 
    #:posix-vdisable
 
+   ;; sys/poll.h
+   #:with-pollfds
+   #:poll-return-event
+   #:poll-error
+   #:poll-hangup
+   #:poll-invalid
    #:pollin
    #:pollpri
    #:pollout
+   #:pollerr
+   #:pollhup
+   #:pollnval
 
    ;; Misc
    #:repeat-upon-condition

--- a/posix/packages.lisp
+++ b/posix/packages.lisp
@@ -128,6 +128,7 @@
    #:opendir
    #:openlog
    #:pipe
+   #:poll
    #:pread
    #:pwrite
    #:read
@@ -388,6 +389,10 @@
    #:tcsaflush
 
    #:posix-vdisable
+
+   #:pollin
+   #:pollpri
+   #:pollout
 
    ;; Misc
    #:repeat-upon-condition

--- a/posix/unix.lisp
+++ b/posix/unix.lisp
@@ -290,16 +290,22 @@
   (fd      file-descriptor-designator)
   (request :int))
 
-(defsyscall ("ioctl" %ioctl-with-arg) :int
+(defsyscall ("ioctl" %ioctl-with-pointer-arg) :int
  (fd      file-descriptor-designator)
  (request :int)
  (arg     :pointer))
+
+(defsyscall ("ioctl" %ioctl-with-integer-arg) :int
+ (fd      file-descriptor-designator)
+ (request :int)
+ (arg     :int))
 
 (defun ioctl (fd request &optional (arg nil argp))
   "Control device."
   (cond
     ((not argp) (%ioctl-without-arg fd request))
-    ((pointerp arg) (%ioctl-with-arg fd request arg))
+    ((pointerp arg) (%ioctl-with-pointer-arg fd request arg))
+    ((integerp arg) (%ioctl-with-integer-arg fd request arg))
     (t (error "Wrong argument to ioctl: ~S" arg))))
 
 ;;;; signal.h

--- a/posix/unix.lisp
+++ b/posix/unix.lisp
@@ -298,7 +298,7 @@
 (defsyscall ("ioctl" %ioctl-with-integer-arg) :int
  (fd      file-descriptor-designator)
  (request :int)
- (arg     :int))
+ (arg     :unsigned-long))
 
 (defun ioctl (fd request &optional (arg nil argp))
   "Control device."

--- a/posix/unixint.lisp
+++ b/posix/unixint.lisp
@@ -42,6 +42,9 @@
          "errno.h" "signal.h" "unistd.h" "termios.h" "sys/ioctl.h" "limits.h"
          "sys/uio.h"  "time.h" "dirent.h" "pwd.h" "grp.h" "syslog.h"
          "sys/resource.h" "stdlib.h" "sys/utsname.h" "sys/statvfs.h"
+         #+linux "sys/poll.h"
+         #+freebsd "poll.h"
+         #+openbsd "poll.h"
          #+linux "sys/syscall.h")
 
 (in-package #:osicat-posix)
@@ -768,3 +771,14 @@
 
 #+linux
 (constant (sys-gettid "SYS_gettid"))
+
+;;;; from sys/poll.h
+
+(cstruct pollfd "struct pollfd"
+         (fd "fd" :type :int)
+         (events "events" :type :short)
+         (revents "revents" :type :short))
+         
+(constant (pollin "POLLIN"))
+(constant (pollpri "POLLPRI"))
+(constant (pollout "POLLOUT"))

--- a/posix/unixint.lisp
+++ b/posix/unixint.lisp
@@ -782,3 +782,6 @@
 (constant (pollin "POLLIN"))
 (constant (pollpri "POLLPRI"))
 (constant (pollout "POLLOUT"))
+(constant (pollerr "POLLERR"))
+(constant (pollhup "POLLHUP"))
+(constant (pollnval "POLLNVAL"))


### PR DESCRIPTION
I'm in need of the ability to use poll() from a number of Lisp implementations and couldn't find it in osicat; this pull requests adds the system call.
