### PR TITLE
Add support for full stat structure on OSX

### DIFF
--- a/posix/basic-unixint.lisp
+++ b/posix/basic-unixint.lisp
@@ -298,6 +298,10 @@
   (ctype blksize "long")
   (ctype blkcnt "long"))
 
+(cstruct timespec "struct timespec"
+   (sec      "tv_sec"  :type time)
+   (nsec     "tv_nsec" :type :long))
+
 (cstruct stat "struct stat"
   (dev     "st_dev"     :type #-mips dev #+mips :unsigned-long)
   (ino     "st_ino"     :type ino)
@@ -309,6 +313,13 @@
   (size    "st_size"    :type off)
   #-windows (blksize "st_blksize" :type blkcnt)
   #-windows (blocks  "st_blocks"  :type blksize)
-  (atime   "st_atime"   :type time)
-  (mtime   "st_mtime"   :type time)
-  (ctime   "st_ctime"   :type time))
+  #-darwin (atime   "st_atime"   :type time)
+  #-darwin (mtime   "st_mtime"   :type time)
+  #-darwin (ctime   "st_ctime"   :type time)
+  #+darwin (atimespec     "st_atimespec"     :type (:struct timespec))
+  #+darwin (mtimespec     "st_mtimespec"     :type (:struct timespec))
+  #+darwin (ctimespec     "st_ctimespec"     :type (:struct timespec))
+  #+darwin (birthtimespec "st_birthtimespec" :type (:struct timespec))
+  #+darwin (flags         "st_flags"         :type :uint32)
+  #+darwin (gen           "st_gen"           :type :uint32))
+

--- a/posix/packages.lisp
+++ b/posix/packages.lisp
@@ -222,6 +222,13 @@
    #:stat-atime
    #:stat-mtime
    #:stat-ctime
+   #:stat-atimespec
+   #:stat-mtimespec
+   #:stat-ctimespec
+   #:stat-birthtimespec
+   #:stat-flags
+   #:stat-gen
+
 
    #:termios
    #:iflag
@@ -235,6 +242,10 @@
    #:col
    #:xpixel
    #:ypixel
+
+   #:timespec
+   #:timespec-sec
+   #:timespec-nsec
 
    ;; Platform-specific Functions
 


### PR DESCRIPTION
The reserved fields I believe necessary since in future versions of OSX they might be used, and the structure provided by CL then will not be of the correct size and will lead to memory corruption.