### PR TITLE
Revert "fd-streams: ecl: provide implementation"

### DIFF
--- a/src/fd-streams.lisp
+++ b/src/fd-streams.lisp
@@ -33,19 +33,6 @@
 #+(or sbcl cmu scl)
 (pushnew :osicat-fd-streams *features*)
 
-#+ecl
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (when (> ext:+ecl-version-number+ 160103)
-    (pushnew :osicat-fd-streams *features*)))
-
-#+(and ecl osicat-fd-streams)
-(defun make-fd-stream (fd &key direction element-type external-format
-                            pathname file)
-  (declare (ignore pathname file))
-  (ext:make-stream-from-fd fd direction
-                           :element-type element-type
-                           :external-format external-format))
-
 #+sbcl
 (defun make-fd-stream (fd &key direction element-type external-format
                        pathname file)


### PR DESCRIPTION
It seems to break Travis tests on Clisp and ECL

This reverts commit 32b11745f5b1d0f359761daef6977483fa586436.