### PR TITLE
Access symbols from inside the package (not exported)

### DIFF
--- a/src/fd-streams.lisp
+++ b/src/fd-streams.lisp
@@ -35,16 +35,16 @@
 
 #+ecl
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (when (> ext:+ecl-version-number+ 160103)
+  (when (> ext::+ecl-version-number+ 160103)
     (pushnew :osicat-fd-streams *features*)))
 
 #+(and ecl osicat-fd-streams)
 (defun make-fd-stream (fd &key direction element-type external-format
                             pathname file)
   (declare (ignore pathname file))
-  (ext:make-stream-from-fd fd direction
-                           :element-type element-type
-                           :external-format external-format))
+  (ext::make-stream-from-fd fd direction
+                            :element-type element-type
+                            :external-format external-format))
 
 #+sbcl
 (defun make-fd-stream (fd &key direction element-type external-format


### PR DESCRIPTION
This is a necessary workaround for CLISP and ECL 16.1.3 (and earlier) – reader
tries to access symbols even if they should be ignored, and if (existing)
package doesn't export such symbol, that leads to error. For more information
see https://gitlab.com/embeddable-common-lisp/ecl/issues/431 . Problem reported
by Alexey Veretennikov.