### PR TITLE
Update fd-streams.lisp

### DIFF
--- a/src/fd-streams.lisp
+++ b/src/fd-streams.lisp
@@ -49,12 +49,13 @@
 #+sbcl
 (defun make-fd-stream (fd &key direction element-type external-format
                        pathname file)
-  (declare (ignore pathname file))
+  (declare (ignore pathname))
   (let ((in-p (member direction '(:io :input)))
         (out-p (member direction '(:io :output))))
     (sb-sys:make-fd-stream fd :input in-p :output out-p
                            :element-type element-type
-                           :external-format external-format)))
+                           :external-format external-format
+                           :file file)))
 
 #+cmu
 (defun make-fd-stream (fd &key direction element-type external-format


### PR DESCRIPTION
Fix error on call `(file-length #<SB-SYS:FD-STREAM for "descriptor 3" {100ACC5FA3}>)': "~S is not a stream associated with a file.":
https://github.com/sbcl/sbcl/blob/0ead38dd6f987ffd82d3f905cdd2590bc4df4fcd/src/code/fd-stream.lisp#L2063