### PR TITLE
Fix the sigev struct to support musl libc

### DIFF
--- a/posix/unixint.lisp
+++ b/posix/unixint.lisp
@@ -46,6 +46,12 @@
 
 (in-package #:osicat-posix)
 
+;; Musl Libc defines this macro, glibc does not.
+#+linux
+(c "#ifndef sigev_notify_thread_id
+#define sigev_notify_thread_id _sigev_un._tid
+#endif")
+
 (constant (sighup "SIGHUP") :documentation "terminal line hangup.")
 (constant (sigquit "SIGQUIT") :documentation "quit program.")
 (constant (sigtrap "SIGTRAP") :documentation "trace trap.")
@@ -114,7 +120,7 @@
   (notify-function   "sigev_notify_function"   :type :pointer)
   (notify-attributes "sigev_notify_attributes" :type :pointer)
   #+linux
-  (notify-thread-id  "_sigev_un._tid"          :type pid))
+  (notify-thread-id  "sigev_notify_thread_id"  :type pid))
 
 ;;;; fcntl()
 


### PR DESCRIPTION
Fixes #19

It appears musl libc has actually added SIGEV_THREAD_ID support. However, the
member name for the thread id in the sigev struct is different than
glibc's. Musl provides a macro with this name (sigev_notify_thread_id), glibc
does not.

Support both by defining this macro if it does not exist. If it does not exist,
the value of the macro is the name of the member in glibc. Then, use this macro
in the subsequent struct definition.

https://git.musl-libc.org/cgit/musl/commit/?id=7c71792e87691451f2a6b76348e83ad1889f1dcb