### PR TITLE
added mkstemps(3).

### DIFF
--- a/posix/linux.lisp
+++ b/posix/linux.lisp
@@ -42,8 +42,8 @@
                                       "XXXXXX"
                                       suffix)))
     (with-foreign-string (ptr-template actual-template)
-      (%mkstemps ptr-template (length suffix))
-      (foreign-string-to-lisp ptr-template))))
+      (values (%mkstemps ptr-template (length suffix))
+              (foreign-string-to-lisp ptr-template)))))
 
 ;;;; sys/syscall.h
 

--- a/posix/linux.lisp
+++ b/posix/linux.lisp
@@ -32,19 +32,6 @@
 (defsyscall "fdatasync" :int
   (fd file-descriptor-designator))
 
-(defsyscall ("mkstemps" %mkstemps) :int
-  (template :pointer)
-  (suffix-length :int))
-
-(defun mkstemps (template suffix)
-  (let ((actual-template (concatenate 'string
-                                      template
-                                      "XXXXXX"
-                                      suffix)))
-    (with-foreign-string (ptr-template actual-template)
-      (values (%mkstemps ptr-template (length suffix))
-              (foreign-string-to-lisp ptr-template)))))
-
 ;;;; sys/syscall.h
 
 (defsyscall ("syscall" syscall) :int

--- a/posix/linux.lisp
+++ b/posix/linux.lisp
@@ -32,6 +32,19 @@
 (defsyscall "fdatasync" :int
   (fd file-descriptor-designator))
 
+(defsyscall ("mkstemps" %mkstemps) :int
+  (template :pointer)
+  (suffix-length :int))
+
+(defun mkstemps (template suffix)
+  (let ((actual-template (concatenate 'string
+                                      template
+                                      "XXXXXX"
+                                      suffix)))
+    (cffi:with-foreign-string (ptr-template actual-template)
+      (%mkstemps ptr-template (length suffix))
+      (cffi:foreign-string-to-lisp ptr-template))))
+
 ;;;; sys/syscall.h
 
 (defsyscall ("syscall" syscall) :int

--- a/posix/linux.lisp
+++ b/posix/linux.lisp
@@ -41,9 +41,9 @@
                                       template
                                       "XXXXXX"
                                       suffix)))
-    (cffi:with-foreign-string (ptr-template actual-template)
+    (with-foreign-string (ptr-template actual-template)
       (%mkstemps ptr-template (length suffix))
-      (cffi:foreign-string-to-lisp ptr-template))))
+      (foreign-string-to-lisp ptr-template))))
 
 ;;;; sys/syscall.h
 

--- a/posix/packages.lisp
+++ b/posix/packages.lisp
@@ -128,6 +128,7 @@
    #:mknod
    #:mknodat
    #:mkstemp
+   #:mkstemps
    #:mktemp
    #:mlock
    #:mlockall
@@ -282,7 +283,6 @@
 
    #+linux #:gettid
    #+linux #:fdatasync
-   #+linux #:mkstemps
    #+linux #:mremap
    #+linux #:syscall
 

--- a/posix/packages.lisp
+++ b/posix/packages.lisp
@@ -282,6 +282,7 @@
 
    #+linux #:gettid
    #+linux #:fdatasync
+   #+linux #:mkstemps
    #+linux #:mremap
    #+linux #:syscall
 

--- a/posix/unix.lisp
+++ b/posix/unix.lisp
@@ -49,6 +49,19 @@
 (defun mkdtemp (&optional (template ""))
   (%mkdtemp (concatenate 'string template "XXXXXX")))
 
+(defsyscall ("mkstemps" %mkstemps) :int
+  (template :pointer)
+  (suffix-length :int))
+
+(defun mkstemps (template suffix)
+  (let ((actual-template (concatenate 'string
+                                      template
+                                      "XXXXXX"
+                                      suffix)))
+    (with-foreign-string (ptr-template actual-template)
+      (values (%mkstemps ptr-template (length suffix))
+              (foreign-string-to-lisp ptr-template)))))
+
 ;;;; unistd.h
 
 ;;; directories

--- a/posix/windows.lisp
+++ b/posix/windows.lisp
@@ -32,8 +32,8 @@
   getegid geteuid getgid getgrgid getgrnam getpagesize getpgid getpgrp getpid getppid
   getpriority getpwnam getpwuid getrlimit getrusage gettimeofday getuid ioctl link linkat
   lockf lstat makedev major minor mkdirat mkdtemp mkfifo mkfifoat mknod mknodat mkstemp
-  mlock mlockall mmap mprotect msync munlock munlockall munmap nice openat opendir openlog
-  pread pwrite readdir readlink readlinkat readv renameat rewinddir seekdir select setegid
-  setenv seteuid setgid setlogmask setpgid setpgrp setpriority setregid setreuid setrlimit
-  setsid setuid statvfs symlink symlinkat sync sysconf syslog telldir truncate uname
-  unlinkat unsetenv usleep utimensat utimes writev s-issock s-islnk gethostname)
+  mkstemps mlock mlockall mmap mprotect msync munlock munlockall munmap nice openat opendir
+  openlog pread pwrite readdir readlink readlinkat readv renameat rewinddir seekdir select
+  setegid setenv seteuid setgid setlogmask setpgid setpgrp setpriority setregid setreuid
+  setrlimit setsid setuid statvfs symlink symlinkat sync sysconf syslog telldir truncate
+  uname unlinkat unsetenv usleep utimensat utimes writev s-issock s-islnk gethostname)


### PR DESCRIPTION
Hi!

I have added a wrapper for `mkstemps` a function that creates a temporary file with an optional suffix, as far as i know this function is not standard so i have added it with a `#+linux` reader macro, i do not know if is the best thing to do as probably there are  other systems that supports this function too but i am not aware of them. 

Hope this helps!
Bye
C.