### PR TITLE
osicat/tests: use SB-RT on SBCL

### DIFF
--- a/osicat.asd
+++ b/osicat.asd
@@ -83,7 +83,9 @@
   :author "Nikodemus Siivola <nikodemus@random-state.net>"
   :description "Osicat test suite"
   :license "MIT"
-  :depends-on (#:osicat #:rt)
+  :depends-on (#:osicat
+               (:feature :sbcl (:require #:sb-rt))
+               (:feature (:not :sbcl) #:rt))
   :components
   ((:module #:tests
     :serial t

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -27,7 +27,7 @@
 (in-package #:cl-user)
 
 (defpackage #:osicat/tests
-  (:use #:common-lisp #:rtest #:osicat)
+  (:use #:common-lisp #+sbcl #:sb-rt #-sbcl #:rtest #:osicat)
   (:export #:run))
 
 (in-package #:osicat/tests)
@@ -35,8 +35,9 @@
 (defun run ()
   (let ((*package* (find-package :osicat/tests)))
     (do-tests)
-    (null (set-difference (rtest:pending-tests)
-                          rtest::*expected-failures*))))
+    (null (set-difference
+           #+sbcl (sb-rt:pending-tests) #-sbcl (rtest:pending-tests)
+           #+sbcl sb-rt::*expected-failures* #-sbcl rtest::*expected-failures*))))
 
 ;;; Utilities
 


### PR DESCRIPTION
This means that SBCL users don't have to install the RT system from some other
source in order to run the test suite.