### PR TITLE
osicat.asd: use feature expressions rather than reader conditionals

### DIFF
--- a/osicat.asd
+++ b/osicat.asd
@@ -50,28 +50,31 @@
     :components
     ((:file "packages")
      (:cffi-grovel-file "basic-unixint")
-     #-windows (:cffi-grovel-file "unixint")
+     (:cffi-grovel-file "unixint" :if-feature (:not :windows))
      (:file "early")
      (:cffi-wrapper-file "wrappers" :soname "libosicat")
      (:file "basic-unix")
-     #-windows (:file "unix")
-     #+linux (:file "linux")
-     #+windows (:file "windows")
+     (:file "unix" :if-feature (:not :windows))
+     (:file "linux" :if-feature :linux)
+     (:file "windows" :if-feature :windows)
      (:file "misc")))
-   #+windows
    (:module #:windows
+    :if-feature :windows
     :depends-on (#:osicat-sys)
     :components
     ((:file "package")
      (:file "windows" :depends-on ("package"))))
-   #+darwin
    (:module #:mach
+    :if-feature :darwin
     :depends-on (#:osicat-sys)
     :components
     ((:file "package")
      (:file "mach" :depends-on ("package"))))
    (:module #:src
-    :depends-on (#:osicat-sys #:posix #+windows #:windows #+darwin #:mach)
+    :depends-on (#:osicat-sys
+                 #:posix
+                 (:feature :windows #:windows)
+                 (:feature :darwin #:mach))
     :components
     ((:file "packages")
      (:file "fd-streams" :depends-on ("packages"))


### PR DESCRIPTION
The ASDF Manual recommends this because it means that code can extract
information about what components and dependencies the system would have on
platforms other than the one the code is running on.

Another possibility this enables is temporarily binding *FEATURES* to match a
target system which is different from the current system, and then using an
operation like ASDF:MONOLITHIC-CONCATENATE-SOURCE-OP to prepare a number of
dependencies for loading up into Lisp on the target system.