### PR TITLE
OSICAT-POSIX: export types extracted using CFFI-Grovel

### DIFF
--- a/posix/packages.lisp
+++ b/posix/packages.lisp
@@ -53,6 +53,15 @@
    #:eshutdown #:etoomanyrefs #:etimedout #:econnrefused #:ehostdown
    #:ehostunreach #:ealready #:einprogress #:estale #:edquot #:enonet
 
+   ;; Types
+   #:size #:ssize #:pid
+   #-windows #:uid
+   #-windows #:gid
+   #:off #:mode #:time #:dev #:ino
+   #-windows #:nlink
+   #-windows #:blksize
+   #-windows #:blkcnt
+
    ;; Functions
    #:access
    #:bzero


### PR DESCRIPTION
It would be useful to have access to these types for using FOREIGN-FUNCALL to call functions osicat doesn't have wrappers for.