### PR TITLE
OSICAT-POSIX: export FCHOWN and LCHOWN

### DIFF
--- a/posix/packages.lisp
+++ b/posix/packages.lisp
@@ -71,6 +71,7 @@
    #:exit
    #:fchdir
    #:fchmod
+   #:fchown
    #:fcntl
    #:posix-fallocate
    #:fork
@@ -102,6 +103,7 @@
    #:ioctl
    #:isatty
    #:kill
+   #:lchown
    #:link
    #:lockf
    #:lseek


### PR DESCRIPTION
Looks like just an oversight that these aren't exported.  Thanks!