### PR TITLE
Fix/openbsd fixes

### DIFF
--- a/posix/basic-unixint.lisp
+++ b/posix/basic-unixint.lisp
@@ -286,20 +286,11 @@
 (ctype dev "dev_t")
 (ctype ino "ino_t")
 
-#-(or windows openbsd)
+#-windows
 (progn
   (ctype nlink "nlink_t")
   (ctype blksize "blksize_t")
   (ctype blkcnt "blkcnt_t"))
-
-#+openbsd
-(progn
-  (ctype nlink "nlink_t")
-  (ctype blksize "long")
-  (ctype blkcnt "long"))
-
-#+windows
-(ctype nlink "short")
 
 (cstruct timespec "struct timespec"
    (sec      "tv_sec"  :type time)

--- a/tests/posix.lisp
+++ b/tests/posix.lisp
@@ -705,6 +705,7 @@
           (nix:close fd))))
   1)
 
+#-(or openbsd netbsd)
 (define-posix-test posix-fallocate.test.1
     (let* ((filename (make-pathname :name "fallocate.test" :type "1"
                                     :defaults *test-directory*))
@@ -718,6 +719,7 @@
           (nix:unlink filename))))
   t)
 
+#-(or openbsd netbsd)
 (define-posix-test posix-fallocate.error.1
     (let ((filename (make-pathname :name "fallocate.error" :type "1"
                                    :defaults *test-directory*)))


### PR DESCRIPTION
Few simple fixes for OpenBSD:
- Recent versions of OpenBSD provides blksize_t so use that
- OpenBSD (and based on absence of man page) NetBSD does not have posix_fallocate so skip testing it

