### PR TITLE
Add :traverse-symlinks key to call-with-directory-iterator,

### DIFF
--- a/tests/osicat.lisp
+++ b/tests/osicat.lisp
@@ -271,6 +271,30 @@
         (delete-directory dir)))
   nil)
 
+;;; Test that symbolic links to directories are interpreted as directory
+;;; designators
+(deftest mapdir.5
+  (let* ((dir (merge-pathnames "mapdir-test.5/" *test-directory*))
+         (link (merge-pathnames "link" dir))
+         (target (merge-pathnames "." dir)))
+    (ensure-directories-exist dir)
+    (ensure-link link :target target)
+    (mapdir #'namestring dir))
+  ("link/"))
+
+;;; Test that :TRAVERSE-SYMLINKS NIL prohibit interpreting symbolic links to
+;;; directories as directory designators
+;;; TRAVERSE-SYMLINKS not implemented on Windows
+#-windows
+(deftest mapdir.6
+  (let* ((dir (merge-pathnames "mapdir-test.6/" *test-directory*))
+         (link (merge-pathnames "link" dir))
+         (target (merge-pathnames "." dir)))
+    (ensure-directories-exist dir)
+    (ensure-link link :target target)
+    (mapdir #'namestring dir :traverse-symlinks nil))
+  ("link"))
+
 ;;; Be careful with this test.  It deletes directories recursively.
 (deftest with-directory-iterator.1
     (let ((dirs (list "wdi-test-1/" ".wdi-test.2/"


### PR DESCRIPTION
Opted for :traverse-symlinks instead of a more traditional :follow-symlinks as it seems to me more appropriate: symlinks are never resolved nor followed, but the ones pointing to directories are (or aren't with :traverse-symlinks nil) interpreted as directory designators.

:traverse-symlinks is not implemented on Windows as I don't have experience on it, but I suspect call-with-directory-iterator should be changed for supporting symbolic-links on Windows.

Rationale: I implemented this patch because walk-directory does not detect loops. This patch solves the issue (sort of) and can be useful in itself. I still think that walk-directory should be able to detect/avoid loops, but I'm not sure it can be done without complicating the code too much.