### PR TITLE
fix: restore build on windows (#62)

### DIFF
--- a/posix/basic-unixint.lisp
+++ b/posix/basic-unixint.lisp
@@ -292,6 +292,8 @@
   (ctype blksize "blksize_t")
   (ctype blkcnt "blkcnt_t"))
 
+#+windows (ctype nlink "short")
+
 (cstruct timespec "struct timespec"
    (sec      "tv_sec"  :type time)
    (nsec     "tv_nsec" :type :long))


### PR DESCRIPTION
As https://github.com/osicat/osicat/issues/62 states, https://github.com/osicat/osicat/commit/a7fbfc16112e1daf33c1d01c2ee2767f8561338a broke build for windows. This PR allows build on windows again