### PR TITLE
fix: use POSIX strerror_r on linux with other libc than glibc (e.e. m…

### DIFF
--- a/posix/basic-unix.lisp
+++ b/posix/basic-unix.lisp
@@ -44,15 +44,8 @@
   (let ((errno (if (keywordp err)
                    (foreign-enum-value 'errno-values err)
                    err)))
-    #-linux ; XSI-compliant strerror_r() always stores the error
-            ; message in the user-supplied buffer.
     (with-foreign-pointer-as-string ((buf bufsiz) 1024)
-      (strerror-r errno buf bufsiz))
-    #+linux ; GNU strerror_r() doesn't always store the error message
-            ; in the user-supplied buffer, but it returns a string
-            ; instead of an int.
-    (with-foreign-pointer (buf 1024 bufsiz)
-      (strerror-r errno buf bufsiz))))
+      (my-strerror-r errno buf bufsiz))))
 
 (defmethod print-object ((posix-error posix-error) stream)
  (print-unreadable-object (posix-error stream :type t :identity nil)

--- a/posix/wrappers.lisp
+++ b/posix/wrappers.lisp
@@ -175,14 +175,27 @@
   "errno = value;"
   "return errno;")
 
-;; Note: since we define _GNU_SOURCE on Linux (to get at mremap()), we
-;; get the GNU version of strerror_r() which doesn't always store the
-;; result in `buf'.
+;; Note: We define _GNU_SOURCE on Linux to get at mremap(). Therefore, we
+;; get the GNU version of strerror_r() when gnu-libc is used and the XSI
+;; version when another libc is used (e.g. musl-libc on apline).
+;; Since there is no way to check at lisp level which libc is in use, we
+;; use an additional wrapper at C-level to provide a consistent interface
 #-windows
-(defwrapper "strerror_r" #+linux :string #-linux :int
-  (errnum :int)
-  (buf :string)
-  (buflen ("size_t" size)))
+(defwrapper* "my_strerror_r" :int
+  ((errnum :int)
+   (buf :string)
+   (buflen ("size_t" size)))
+  "#if defined(_GNU_SOURCE) && defined(__GLIBC__)"
+  "    char *ret = strerror_r (errnum, buf, buflen);"
+  "    if (ret != buf) {"
+  "        buf[0] = '\0';"
+  "        strncat (buf, error, n - 1);"
+  "    }"
+  "    return 0";
+  "#else"
+  "    return strerror_r (errnum, buf, buflen);"
+  "# endif"
+  )
 
 #-windows
 (defwrapper* "log_mask" :int ((priority :int))


### PR DESCRIPTION
…usl-libc on alpine-linux)

Fixes issue #71