### PR TITLE
fix: use POSIX strerror_r on linux with other libc than glibc (e.e. m…

### DIFF
--- a/posix/basic-unix.lisp
+++ b/posix/basic-unix.lisp
@@ -44,15 +44,8 @@
   (let ((errno (if (keywordp err)
                    (foreign-enum-value 'errno-values err)
                    err)))
-    #-linux ; XSI-compliant strerror_r() always stores the error
-            ; message in the user-supplied buffer.
     (with-foreign-pointer-as-string ((buf bufsiz) 1024)
-      (strerror-r errno buf bufsiz))
-    #+linux ; GNU strerror_r() doesn't always store the error message
-            ; in the user-supplied buffer, but it returns a string
-            ; instead of an int.
-    (with-foreign-pointer (buf 1024 bufsiz)
-      (strerror-r errno buf bufsiz))))
+      (my-strerror-r errno buf bufsiz))))
 
 (defmethod print-object ((posix-error posix-error) stream)
  (print-unreadable-object (posix-error stream :type t :identity nil)


### PR DESCRIPTION
…usl-libc on alpine-linux)

Fixes issue #71