### PR TITLE
fix: use POSIX strerror_r on linux with other libc than glibc (e.g. m…

### DIFF
--- a/osicat.asd
+++ b/osicat.asd
@@ -53,6 +53,7 @@
      (:cffi-grovel-file "unixint" :if-feature (:not :windows))
      (:file "early")
      (:cffi-wrapper-file "wrappers" :soname "libosicat")
+     (:cffi-wrapper-file "wrapper-mremap" :soname "libosicat-mremap")
      (:file "basic-unix")
      (:file "unix" :if-feature (:not :windows))
      (:file "linux" :if-feature :linux)

--- a/posix/basic-unix.lisp
+++ b/posix/basic-unix.lisp
@@ -32,26 +32,21 @@
 
 ;;;; POSIX-ERROR
 
+;;; TODO: make errnum parameter optional and accept keywords on windows
 #+windows
 (defcfun "strerror" :string
   "Look up the error message string for ERRNO. (reentrant)"
   (errnum :int))
 
-;;; TODO: accept keywords too?
 #-windows
 (defun strerror (&optional (err (get-errno)))
   "Look up the error message string for ERRNO. (reentrant)"
   (let ((errno (if (keywordp err)
                    (foreign-enum-value 'errno-values err)
                    err)))
-    #-linux ; XSI-compliant strerror_r() always stores the error
-            ; message in the user-supplied buffer.
+    ;; XSI-compliant strerror_r() always stores the error
+    ;; message in the user-supplied buffer.
     (with-foreign-pointer-as-string ((buf bufsiz) 1024)
-      (strerror-r errno buf bufsiz))
-    #+linux ; GNU strerror_r() doesn't always store the error message
-            ; in the user-supplied buffer, but it returns a string
-            ; instead of an int.
-    (with-foreign-pointer (buf 1024 bufsiz)
       (strerror-r errno buf bufsiz))))
 
 (defmethod print-object ((posix-error posix-error) stream)

--- a/posix/wrapper-mremap.lisp
+++ b/posix/wrapper-mremap.lisp
@@ -1,0 +1,46 @@
+;;;; -*- Mode: lisp; indent-tabs-mode: nil -*-
+;;;
+;;; wrappers.lisp --- Grovel wrapper definitions.
+;;;
+;;; Copyright (C) 2007, Luis Oliveira  <loliveira@common-lisp.net>
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+
+(in-package #:osicat-posix)
+
+(c "#if defined(__linux__)")
+(define "_XOPEN_SOURCE" 600)
+(define "_LARGEFILE_SOURCE")
+(define "_LARGEFILE64_SOURCE")
+(define "_FILE_OFFSET_BITS" 64)
+(define "_GNU_SOURCE")
+(c "#endif")
+
+#+linux
+(progn
+  (include "sys/mman.h")
+  (defwrapper "mremap" ("void*" (errno-wrapper
+                                 :pointer
+                                 :error-predicate (lambda (p) (pointer-eq p *map-failed-pointer*))))
+    (old-address :pointer)
+    (old-size ("size_t" size))
+    (new-size ("size_t" size))
+    (flags :int)))

--- a/posix/wrappers.lisp
+++ b/posix/wrappers.lisp
@@ -31,7 +31,6 @@
 (define "_LARGEFILE_SOURCE")
 (define "_LARGEFILE64_SOURCE")
 (define "_FILE_OFFSET_BITS" 64)
-(define "_GNU_SOURCE")
 (c "#endif")
 
 (include "string.h" "errno.h"  "sys/types.h" "sys/stat.h"
@@ -71,15 +70,6 @@
   (flags :int)
   (fd ("int" file-descriptor-designator))
   (offset ("off_t" off)))
-
-#+linux
-(defwrapper "mremap" ("void*" (errno-wrapper
-                               :pointer
-                               :error-predicate (lambda (p) (pointer-eq p *map-failed-pointer*))))
-  (old-address :pointer)
-  (old-size ("size_t" size))
-  (new-size ("size_t" size))
-  (flags :int))
 
 (defwrapper ("stat" %stat) ("int" (errno-wrapper :int))
   (file-name ("const char*" filename-designator))
@@ -175,11 +165,8 @@
   "errno = value;"
   "return errno;")
 
-;; Note: since we define _GNU_SOURCE on Linux (to get at mremap()), we
-;; get the GNU version of strerror_r() which doesn't always store the
-;; result in `buf'.
 #-windows
-(defwrapper "strerror_r" #+linux :string #-linux :int
+(defwrapper "strerror_r" :int
   (errnum :int)
   (buf :string)
   (buflen ("size_t" size)))

--- a/tests/posix.lisp
+++ b/tests/posix.lisp
@@ -732,3 +732,15 @@
                 (nix:unlink filename))))
         (nix:einval (c) 'failed)))
   failed)
+
+(define-posix-test errno.1
+    (nix:strerror :eperm)
+  "Operation not permitted")
+
+(define-posix-test errno.2
+    (nix:strerror :enoent)
+  "No such file or directory")
+
+(define-posix-test errno.3
+    (nix:strerror :eacces)
+  "Permission denied")


### PR DESCRIPTION
…usl-libc on alpine-linux)
- Fixes issue #71

This PR splits mremap() off into its own translation unit. Drawback is that a second libosicat-remap.so file is created.
